### PR TITLE
Amended partition validation to fails if contains '.' as dot-notation isn't supported. Closes #214

### DIFF
--- a/internal/config/partition.go
+++ b/internal/config/partition.go
@@ -97,16 +97,16 @@ func (c *Partition) Validate() hcl.Diagnostics {
 		if strings.Contains(c.Filter, ";") {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Partition filter contains a semicolon",
-				Detail:   fmt.Sprintf("Partition %s should not contain ';' in filter.", c.GetUnqualifiedName()),
+				Summary:  fmt.Sprintf("Partition %s contains invalid filter", c.GetUnqualifiedName()),
+				Detail:   "multiple expressions are not supported in partition filters, should not contain ';'.",
 			})
 		}
 		// check for `/*`, `*/`, `--` to prevent comments
 		if strings.Contains(c.Filter, "/*") || strings.Contains(c.Filter, "*/") || strings.Contains(c.Filter, "--") {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Filter contains a comment",
-				Detail:   fmt.Sprintf("Partition %s should not contain comment identifiers ('/*', '*/', '--') in filter.", c.GetUnqualifiedName()),
+				Summary:  fmt.Sprintf("Partition %s contains invalid filter", c.GetUnqualifiedName()),
+				Detail:   "comments are not supported in partition filters, should not contain  comment identifiers '/*', '*/' or '--'.",
 			})
 		}
 
@@ -131,8 +131,8 @@ func (c *Partition) Validate() hcl.Diagnostics {
 				str := strings.Trim(s, " ")
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagError,
-					Summary:  "Filter contains a keyword",
-					Detail:   fmt.Sprintf("Partition %s should not contain keyword '%s' in filter, unless used as a quoted identifier ('\"%s\"').", c.GetUnqualifiedName(), str, str),
+					Summary:  fmt.Sprintf("Partition %s contains invalid filter", c.GetUnqualifiedName()),
+					Detail:   fmt.Sprintf("should not contain keyword '%s' in filter, unless used as a quoted identifier ('\"%s\"') to prevent unintended behavior.", str, str),
 				})
 			}
 		}
@@ -141,8 +141,8 @@ func (c *Partition) Validate() hcl.Diagnostics {
 		if strings.Contains(c.Filter, ".") {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
-				Summary:  "Filter contains dot notation",
-				Detail:   fmt.Sprintf("Partition %s contains '.' in filter, dot-notation is currently unsupported, please use arrow-notation instead (field->>'sub_field' != 'value').", c.GetUnqualifiedName()),
+				Summary:  fmt.Sprintf("Partition %s contains invalid filter", c.GetUnqualifiedName()),
+				Detail:   "dot-notation is currently unsupported in partition filters, please use arrow-notation instead (field->>'sub_field' != 'value').",
 			})
 		}
 	}

--- a/internal/config/partition.go
+++ b/internal/config/partition.go
@@ -136,6 +136,15 @@ func (c *Partition) Validate() hcl.Diagnostics {
 				})
 			}
 		}
+
+		// check for `.` (dot notation) as we currently don't support this as structs aren't compiled at this stage
+		if strings.Contains(c.Filter, ".") {
+			diags = append(diags, &hcl.Diagnostic{
+				Severity: hcl.DiagError,
+				Summary:  "Filter contains dot notation",
+				Detail:   fmt.Sprintf("Partition %s contains '.' in filter, dot-notation is currently unsupported, please use arrow-notation instead (field->>'sub_field' != 'value').", c.GetUnqualifiedName()),
+			})
+		}
 	}
 
 	return diags


### PR DESCRIPTION
Closes #214 