### PR TITLE
DeleteParquetFiles only prunes the partition folder. Closes #227

### DIFF
--- a/cmd/collect.go
+++ b/cmd/collect.go
@@ -116,7 +116,6 @@ func doCollect(ctx context.Context, cancel context.CancelFunc, args []string) er
 				errList = append(errList, err)
 				continue
 			}
-			error_helpers.FailOnError(err)
 		}
 		// do the collection
 		err = collectPartition(ctx, cancel, partition, fromTime, pluginManager)

--- a/internal/display/partition.go
+++ b/internal/display/partition.go
@@ -3,17 +3,15 @@ package display
 import (
 	"context"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/dustin/go-humanize"
-
 	"github.com/turbot/pipe-fittings/v2/printers"
 	"github.com/turbot/tailpipe/internal/config"
-	"github.com/turbot/tailpipe/internal/constants"
 	"github.com/turbot/tailpipe/internal/database"
 )
 
+// PartitionResource represents a partition resource and is used for list/show commands
 type PartitionResource struct {
 	Name        string             `json:"name"`
 	Description *string            `json:"description,omitempty"`
@@ -91,10 +89,9 @@ func (r *PartitionResource) setFileInformation() error {
 	dataDir := config.GlobalWorkspaceProfile.GetDataDir()
 
 	nameParts := strings.Split(r.Name, ".")
-	tableDir := fmt.Sprintf("%s=%s", constants.TpTable, nameParts[0])
-	partitionDir := fmt.Sprintf("%s=%s", constants.TpPartition, nameParts[1])
 
-	metadata, err := getFileMetadata(path.Join(dataDir, tableDir, partitionDir))
+	partitionDir := filepaths.GetParquetPartitionPath(dataDir, nameParts[0], nameParts[1])
+	metadata, err := getFileMetadata(partitionDir)
 	if err != nil {
 		return err
 	}

--- a/internal/filepaths/parquet.go
+++ b/internal/filepaths/parquet.go
@@ -2,6 +2,8 @@ package filepaths
 
 import (
 	"fmt"
+
+	pfilepaths "github.com/turbot/pipe-fittings/v2/filepaths"
 	"path/filepath"
 )
 
@@ -13,6 +15,6 @@ func GetParquetFileGlobForPartition(dataDir, tableName, partitionName, fileRoot 
 	return filepath.Join(dataDir, fmt.Sprintf("tp_table=%s/tp_partition=%s/*/*/%s*.parquet", tableName, partitionName, fileRoot))
 }
 
-func GetParquetPartitionPath(dataDir, tableName, partitionName, fileRoot string) string {
+func GetParquetPartitionPath(dataDir, tableName, partitionName string) string {
 	return filepath.Join(dataDir, fmt.Sprintf("tp_table=%s/tp_partition=%s", tableName, partitionName))
 }

--- a/internal/filepaths/prune.go
+++ b/internal/filepaths/prune.go
@@ -8,6 +8,10 @@ import (
 
 // PruneTree recursively deletes empty directories in the given folder.
 func PruneTree(folder string) error {
+	// if folder does not exist, return
+	if _, err := os.Stat(folder); os.IsNotExist(err) {
+		return nil
+	}
 	isEmpty, err := isDirEmpty(folder)
 	if err != nil {
 		return err

--- a/internal/parquet/delete.go
+++ b/internal/parquet/delete.go
@@ -33,8 +33,9 @@ func DeleteParquetFiles(partition *config.Partition, from time.Time) (int, error
 		return 0, fmt.Errorf("failed to delete partition: %w", err)
 	}
 
-	// delete all empty folders underneath the data
-	pruneErr := filepaths.PruneTree(dataDir)
+	// delete all empty folders underneath the partition folder
+	partitionDir := filepaths.GetParquetPartitionPath(dataDir, partition.TableName, partition.ShortName)
+	pruneErr := filepaths.PruneTree(partitionDir)
 	if pruneErr != nil {
 		// do not return error - just log
 		slog.Warn("DeleteParquetFiles failed to prune empty folders", "error", pruneErr)
@@ -107,7 +108,7 @@ func deletePartition(db *sql.DB, dataDir string, partition *config.Partition) (i
 		return 0, fmt.Errorf("failed to query parquet file count: %w", err)
 	}
 
-	partitionFolder := filepaths.GetParquetPartitionPath(dataDir, partition.TableName, partition.ShortName, "")
+	partitionFolder := filepaths.GetParquetPartitionPath(dataDir, partition.TableName, partition.ShortName)
 	err = os.RemoveAll(partitionFolder)
 	if err != nil {
 		return 0, fmt.Errorf("failed to delete partition folder: %w", err)

--- a/internal/plugin_manager/plugin_manager.go
+++ b/internal/plugin_manager/plugin_manager.go
@@ -97,7 +97,7 @@ func (p *PluginManager) Collect(ctx context.Context, partition *config.Partition
 
 	// the collection temp dir is a subfolder of the collection dir, which has
 	// with the form: ~/.tailpipe/collection/<profile_name>/<pid>/
-	// it is used to write JSONL files and sourctemporary source artifact files
+	// it is used to write JSONL files and temporary source artifact files
 	// it is expected all this data will be cleaned up after the collection is complete
 	// these folders are subject to cleanup in the future
 
@@ -338,7 +338,7 @@ func (p *PluginManager) readCollectionEvents(ctx context.Context, pluginStream p
 				return
 			}
 		case protoEvent := <-pluginEventChan:
-			// convert the protobuff event to an observer event
+			// convert the protobuf event to an observer event
 			// and send it to the observer
 			if protoEvent == nil {
 				// TODO #error unexpected - raise an error - send error to observers


### PR DESCRIPTION
PruneTree handles non target existent folder
Fix multi-partition error handling - collect all partitions if one fails update PartitionResource.setFileInformation to use filepaths.GetParquetPartitionPath