### PR TITLE
refactor: moved statushook to prompt ctx (parent of query), allows info messages at prompt startup. Closes #239

### DIFF
--- a/internal/interactive/interactive_client.go
+++ b/internal/interactive/interactive_client.go
@@ -344,9 +344,6 @@ func (c *InteractiveClient) executor(ctx context.Context, line string) {
 }
 
 func (c *InteractiveClient) executeQuery(ctx context.Context, queryCtx context.Context, resolvedQuery *ResolvedQuery) {
-	// add a spinner to the context
-	queryCtx = statushooks.AddStatusHooksToContext(queryCtx, statushooks.NewStatusSpinnerHook())
-
 	_, err := query.ExecuteQuery(queryCtx, resolvedQuery.ExecuteSQL, c.db)
 	if err != nil {
 		error_helpers.ShowError(ctx, error_helpers.HandleCancelError(err))

--- a/internal/interactive/interactive_client_cancel.go
+++ b/internal/interactive/interactive_client_cancel.go
@@ -3,6 +3,8 @@ package interactive
 import (
 	"context"
 	"log"
+
+	"github.com/turbot/pipe-fittings/v2/statushooks"
 )
 
 // create a cancel context for the interactive prompt, and set c.cancelFunc
@@ -13,6 +15,9 @@ func (c *InteractiveClient) createPromptContext(parentContext context.Context) c
 	}
 	ctx, cancel := context.WithCancel(parentContext)
 	c.cancelPrompt = cancel
+
+	ctx = statushooks.AddStatusHooksToContext(ctx, statushooks.NewStatusSpinnerHook())
+
 	return ctx
 }
 


### PR DESCRIPTION
Closes #239