### PR TITLE
fix: plugin list command now correctly cases keys in JSON output. Closes #332

### DIFF
--- a/internal/display/plugin.go
+++ b/internal/display/plugin.go
@@ -12,9 +12,9 @@ import (
 )
 
 type PluginListDetails struct {
-	Name       string
-	Version    string
-	Partitions []string
+	Name       string   `json:"name"`
+	Version    string   `json:"version"`
+	Partitions []string `json:"partitions"`
 }
 
 // GetListData implements the printers.Listable interface


### PR DESCRIPTION
Closes #332 