### PR TITLE
fix: Add validation for missing source block in partition config

### DIFF
--- a/internal/config/partition.go
+++ b/internal/config/partition.go
@@ -102,7 +102,8 @@ func (c *Partition) Validate() hcl.Diagnostics {
 	if c.Source.Type == "" {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("Partition %s is missing required source block", c.GetUnqualifiedName()),
+			Summary:  fmt.Sprintf("Partition '%s' is missing required source block", c.GetUnqualifiedName()),
+			Subject:  c.ConfigRange.HclRange().Ptr(),
 		})
 	}
 

--- a/internal/config/partition.go
+++ b/internal/config/partition.go
@@ -98,6 +98,15 @@ func (c *Partition) CollectionStatePath(collectionDir string) string {
 func (c *Partition) Validate() hcl.Diagnostics {
 	var diags hcl.Diagnostics
 
+	// validate source block is present
+	if c.Source.Type == "" {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  fmt.Sprintf("Partition %s is missing required source block", c.GetUnqualifiedName()),
+			Detail:   "A source block is required for every partition to specify the data source.",
+		})
+	}
+
 	// validate filter
 	if c.Filter != "" {
 		diags = append(diags, c.validateFilter()...)

--- a/internal/config/partition.go
+++ b/internal/config/partition.go
@@ -103,7 +103,6 @@ func (c *Partition) Validate() hcl.Diagnostics {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  fmt.Sprintf("Partition %s is missing required source block", c.GetUnqualifiedName()),
-			Detail:   "A source block is required for every partition to specify the data source.",
 		})
 	}
 

--- a/internal/parse/decode.go
+++ b/internal/parse/decode.go
@@ -2,8 +2,9 @@ package parse
 
 import (
 	"fmt"
-	"github.com/zclconf/go-cty/cty/gocty"
 	"strings"
+
+	"github.com/zclconf/go-cty/cty/gocty"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -213,6 +214,12 @@ func decodeConnection(block *hcl.Block, parseCtx *ConfigParseContext, resource m
 func handleUnknownHcl(block *hcl.Block, parseCtx *ConfigParseContext, unknownAttrs []*hcl.Attribute, unknownBlocks []*hcl.Block) (*config.HclBytes, hcl.Diagnostics) {
 	var diags hcl.Diagnostics
 	unknown := &config.HclBytes{}
+
+	// First, include the block's own range
+	hclBytes := parseCtx.FileData[block.DefRange.Filename]
+	blockRange := hclhelpers.BlockRangeWithLabels(block)
+	unknown.Merge(config.HclBytesForLines(hclBytes, blockRange))
+
 	for _, attr := range unknownAttrs {
 		//	get the hcl bytes for the file
 		hclBytes := parseCtx.FileData[block.DefRange.Filename]
@@ -456,8 +463,7 @@ func resourceForBlock(block *hcl.Block) (modconfig.HclResource, hcl.Diagnostics)
 			Severity: hcl.DiagError,
 			Summary:  fmt.Sprintf("resourceForBlock called for unsupported block type %s", block.Type),
 			Subject:  hclhelpers.BlockRangePointer(block),
-		},
-		}
+		}}
 	}
 
 	name := fmt.Sprintf("%s.%s", block.Type, strings.Join(block.Labels, "."))

--- a/internal/parse/diags.go
+++ b/internal/parse/diags.go
@@ -2,9 +2,10 @@ package parse
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/turbot/pipe-fittings/v2/error_helpers"
-	"strings"
 )
 
 // reimplement this as the pipe fittings version raises an internal error
@@ -31,6 +32,11 @@ func HclDiagsToError(prefix string, diags hcl.Diagnostics) error {
 		prefixStr := ""
 		if prefix != "" {
 			prefixStr = prefix + ": "
+		}
+		// If the error string contains range information on a new line, move it to the same line
+		if strings.Contains(res, "\n(") {
+			parts := strings.SplitN(res, "\n(", 2)
+			res = fmt.Sprintf("%s (%s", parts[0], parts[1])
 		}
 		return fmt.Errorf("%s%s", prefixStr, res)
 	}


### PR DESCRIPTION
Fixes #386 - Empty partition crashes with nil pointer dereference when source block is missing.

The issue occurs when a partition is defined without a source block, causing a nil pointer dereference when trying to access the source's connection. Added validation in Partition.Validate() to check for missing source block and provide a clear error message before the crash occurs.

Test case added to verify the validation works correctly.

<img width="978" alt="Screenshot 2025-04-29 at 10 59 27 AM" src="https://github.com/user-attachments/assets/72b3c492-a20d-49a3-b18f-37570321472e" />

