### PR TITLE
Fix parquet conversion CGO exception for low memory situations  

### DIFF
--- a/internal/parquet/conversion_worker_test.go
+++ b/internal/parquet/conversion_worker_test.go
@@ -62,8 +62,6 @@ import (
 //	}
 //}
 
-// TODO KAI FIX
-//func TestBuildViewQuery(t *testing.T) {
 //	// set the version explicitly here since version is set during build time
 //	// then set the app specific constants needed for the tests
 //	viper.Set("main.version", "0.0.1")

--- a/internal/parquet/convertor.go
+++ b/internal/parquet/convertor.go
@@ -19,7 +19,7 @@ const chunkBufferLength = 1000
 const defaultWorkerMemoryMb = 4096
 
 // the minimum memory to assign to each worker -
-const minWorkerMemoryMb = 1024
+const minWorkerMemoryMb = 512
 
 // Converter struct executes all the conversions for a single collection
 // it therefore has a unique execution id, and will potentially convert of multiple JSONL files
@@ -287,14 +287,14 @@ func (w *Converter) createWorkers(ctx context.Context) error {
 		}
 	}
 
-	slog.Info("Work memory allocation", "workerCount", workerCount, "memoryPerWorkerMb", memoryPerWorkerMb, "maxMemoryMb", maxMemoryMb, "minWorkerMemoryMb", minWorkerMemoryMb)
+	slog.Info("Worker memory allocation", "workerCount", workerCount, "memoryPerWorkerMb", memoryPerWorkerMb, "maxMemoryMb", maxMemoryMb, "minWorkerMemoryMb", minWorkerMemoryMb)
 
 	// create the job channel
 	w.jobChan = make(chan *parquetJob, workerCount*2)
 
 	// start the workers
 	for i := 0; i < workerCount; i++ {
-		wk, err := newConversionWorker(w, memoryPerWorkerMb)
+		wk, err := newConversionWorker(w, memoryPerWorkerMb, i)
 		if err != nil {
 			return fmt.Errorf("failed to create worker: %w", err)
 		}

--- a/internal/plugin/plugin_manager.go
+++ b/internal/plugin/plugin_manager.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"math/rand/v2"
 	"os"
@@ -374,7 +373,7 @@ func (p *PluginManager) getPluginCommand(tp *pplugin.Plugin) (*exec.Cmd, error) 
 	// set the max memory for the plugin (if specified)
 	maxMemoryBytes := tp.GetMaxMemoryBytes()
 	if maxMemoryBytes != 0 {
-		log.Printf("[INFO] Setting max memory for plugin '%s' to %d Mb", tp.Alias, maxMemoryBytes)
+		slog.Info("Setting max memory for plugin", "plugin", tp.Alias, "max memory (mb)", maxMemoryBytes/(1024*1024))
 		// set GOMEMLIMIT for the plugin command env
 		cmd.Env = append(os.Environ(), fmt.Sprintf("GOMEMLIMIT=%d", maxMemoryBytes))
 	}


### PR DESCRIPTION
When creating a temp dir for duckDB, ensure each connection has its own temp dir to avoid swap-file name clash
Better logging of memory limits
Remove code to set partition count based on available memory - rely solely on the failure catching algorithm which now works reliably
Fix bug in forceMemoryRelease - use same syntax as DuckDb struct mem limit (set max_memory vs PRAGMA) 
Reduce min worker mem to 512 Mb