### PR TITLE
Release Tailpipe v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 _What's new_
 * Add support for memory and temp storage limits for CLI and plugins. ([#396](https://github.com/turbot/tailpipe/issues/396), [#397](https://github.com/turbot/tailpipe/issues/397))
   * `memory_max_mb` controls CLI memory usage and conversion worker count and memory allocation.
-  * `plugin_max_memory_mb` controls a per-plugin soft memory cap.
-  * `max_temp_dir_mb` limits size of temp data written to disk during a conversion.
+  * `plugin_memory_max_mb` controls a per-plugin soft memory cap.
+  * `temp_dir_max_mb` limits size of temp data written to disk during a conversion.
   * conversion worker count is now based on memory limit, if set.
   * JSONL to Parquet conversion is now executed in multiple passes, limiting the number of distinct partition keys per conversion.
 * Detect and report when a plugin crashes. ([#341](https://github.com/turbot/tailpipe/issues/341))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.4.1 [2025-05-19]
+* Update core plugin to v0.2.5
+  * Update checkJsonlSize to skip check if no min size is set. ([#204](https://github.com/turbot/tailpipe-plugin-sdk/issues/204))
+
 ## v0.4.0 [2025-05-16]
 _What's new_
 * Add support for memory and temp storage limits for CLI and plugins. ([#396](https://github.com/turbot/tailpipe/issues/396), [#397](https://github.com/turbot/tailpipe/issues/397))

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/turbot/go-kit v1.3.0
 	github.com/turbot/pipe-fittings/v2 v2.4.1
-	github.com/turbot/tailpipe-plugin-sdk v0.6.0
+	github.com/turbot/tailpipe-plugin-sdk v0.6.1
 	github.com/zclconf/go-cty v1.14.4
 	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
 
@@ -41,7 +41,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.5.9
 	github.com/marcboeker/go-duckdb/v2 v2.1.0
 	github.com/thediveo/enumflag/v2 v2.0.5
-	github.com/turbot/tailpipe-plugin-core v0.2.4
+	github.com/turbot/tailpipe-plugin-core v0.2.5
 	golang.org/x/sync v0.12.0
 	golang.org/x/text v0.23.0
 	google.golang.org/protobuf v1.36.1

--- a/go.sum
+++ b/go.sum
@@ -773,10 +773,10 @@ github.com/turbot/pipe-fittings/v2 v2.4.1 h1:HncLdttMSjEyx7E8xTQ9xBfbz9JLoycp3YS
 github.com/turbot/pipe-fittings/v2 v2.4.1/go.mod h1:szte433cBDCaZcGe5zMVGG7uTl9HMaEYaQmuvzZRYIQ=
 github.com/turbot/pipes-sdk-go v0.12.0 h1:esbbR7bALa5L8n/hqroMPaQSSo3gNM/4X0iTmHa3D6U=
 github.com/turbot/pipes-sdk-go v0.12.0/go.mod h1:Mb+KhvqqEdRbz/6TSZc2QWDrMa5BN3E4Xw+gPt2TRkc=
-github.com/turbot/tailpipe-plugin-core v0.2.4 h1:dy7a0uAweiBWO4dfr2DOgEA74iF5kZ68rcSph9/2Jsg=
-github.com/turbot/tailpipe-plugin-core v0.2.4/go.mod h1:i+ysfoJmknsp1/3l5XvEn28Y3K84Y8lxWDej4/4IUIk=
-github.com/turbot/tailpipe-plugin-sdk v0.6.0 h1:WL1I4pwVr0AeCaYJ7HPsva5SumO3D5ZhcEcVAFBSjNs=
-github.com/turbot/tailpipe-plugin-sdk v0.6.0/go.mod h1:is7Hh1u0yZS2nJ2HXwV9BpDMpuDycIt/gJtE10ufMss=
+github.com/turbot/tailpipe-plugin-core v0.2.5 h1:wFgV28mvhBde3ib7MV77a7baXKsEbPD1Np2/qwaBFGQ=
+github.com/turbot/tailpipe-plugin-core v0.2.5/go.mod h1:9dvd9GWeAeHhcG3VRSL3bu2BiBlxO3uRs1dCfLL3SBI=
+github.com/turbot/tailpipe-plugin-sdk v0.6.1 h1:njvltko/e8laUILN1FouOy5c7LKEPopNIVPR1OIOurc=
+github.com/turbot/tailpipe-plugin-sdk v0.6.1/go.mod h1:is7Hh1u0yZS2nJ2HXwV9BpDMpuDycIt/gJtE10ufMss=
 github.com/turbot/terraform-components v0.0.0-20231213122222-1f3526cab7a7 h1:qDMxFVd8Zo0rIhnEBdCIbR+T6WgjwkxpFZMN8zZmmjg=
 github.com/turbot/terraform-components v0.0.0-20231213122222-1f3526cab7a7/go.mod h1:5hzpfalEjfcJWp9yq75/EZoEu2Mzm34eJAPm3HOW2tw=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=

--- a/internal/constants/plugin.go
+++ b/internal/constants/plugin.go
@@ -3,7 +3,7 @@ package constants
 const (
 	CorePluginName       = "core"
 	CorePluginFullName   = "hub.tailpipe.io/plugins/turbot/core@latest"
-	MinCorePluginVersion = "v0.2.4"
+	MinCorePluginVersion = "v0.2.5"
 	// TailpipeHubOCIBase is the tailpipe hub URL
 	TailpipeHubOCIBase = "hub.tailpipe.io/"
 	// BaseImageRef is the prefix for all tailpipe plugin images


### PR DESCRIPTION
## Release Issue

[Tailpipe v0.4.1](https://github.com/turbot/tailpipe/issues/428)

## Checklist

- [x] Confirmed that version has been correctly upgraded.