### PR TITLE
DuckDB meta queries will also show suggested table names. Closes #357

### DIFF
--- a/internal/interactive/interactive_client.go
+++ b/internal/interactive/interactive_client.go
@@ -477,6 +477,9 @@ func (c *InteractiveClient) queryCompleter(d prompt.Document) []prompt.Suggest {
 	case isFirstWord(text):
 		suggestions := c.getFirstWordSuggestions(text)
 		s = append(s, suggestions...)
+	case isDuckDbMetaQuery(text):
+		tableSuggestions := c.getTableSuggestions(lastWord(text))
+		s = append(s, tableSuggestions...)
 	case metaquery.IsMetaQuery(text):
 		suggestions := metaquery.Complete(&metaquery.CompleterInput{
 			Query:           text,
@@ -497,8 +500,15 @@ func (c *InteractiveClient) getFirstWordSuggestions(word string) []prompt.Sugges
 
 	var s []prompt.Suggest
 	// add all we know that can be the first words
-	// "select", "with"
-	s = append(s, prompt.Suggest{Text: "select", Output: "select"}, prompt.Suggest{Text: "with", Output: "with"})
+	// "select", "with", "describe", "show", "summarize"
+	s = append(s,
+		prompt.Suggest{Text: "select", Output: "select"},
+		prompt.Suggest{Text: "with", Output: "with"},
+		prompt.Suggest{Text: "describe", Output: "describe"},
+		prompt.Suggest{Text: "show", Output: "show"},
+		prompt.Suggest{Text: "summarize", Output: "summarize"},
+		prompt.Suggest{Text: "explain", Output: "explain"},
+	)
 	// metaqueries
 	s = append(s, metaquery.PromptSuggestions()...)
 	return s

--- a/internal/interactive/interactive_helpers.go
+++ b/internal/interactive/interactive_helpers.go
@@ -76,6 +76,21 @@ func lastWord(text string) string {
 	return text[strings.LastIndex(text, " "):]
 }
 
+// isDuckDbMetaQuery returns true if the input string equals 'describe', 'show', or 'summarize'
+func isDuckDbMetaQuery(s string) bool {
+	ts := strings.ToLower(strings.TrimSpace(s))
+	switch {
+	case ts == "describe":
+		return true
+	case ts == "show":
+		return true
+	case ts == "summarize":
+		return true
+	default:
+		return false
+	}
+}
+
 //
 // keeping this around because we may need
 // to revisit exit on non-darwin platforms.


### PR DESCRIPTION
Enhancements:

- Show first word suggestions now also suggests DuckDB meta queries(describe, show, suggest, explain) - previously only had select and with.
![Screenshot 2025-05-29 at 2 35 14 PM](https://github.com/user-attachments/assets/709f89e9-c5d7-40f9-9d48-5b6d9db1096c)

- DuckDB meta queries now suggest table names
![Screenshot 2025-05-29 at 2 36 22 PM](https://github.com/user-attachments/assets/551c23f8-ed11-45c9-86b0-5af564131bdf)
![Screenshot 2025-05-29 at 2 36 50 PM](https://github.com/user-attachments/assets/443a3f46-5935-4c4a-a872-fda626744e66)
