### PR TITLE
Add smoke test automation workflow and scripts

### DIFF
--- a/.github/workflows/02-tailpipe-smoke-tests.yaml
+++ b/.github/workflows/02-tailpipe-smoke-tests.yaml
@@ -1,0 +1,194 @@
+name: "02 - Tailpipe: Smoke Tests"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to test (with 'v' prefix, e.g., v1.0.0)"
+        required: true
+        type: string
+
+env:
+  # Version from input
+  VERSION: ${{ github.event.inputs.version }}
+  # Disable update checks during smoke tests
+  TAILPIPE_UPDATE_CHECK: false
+
+  jobs:
+  smoke_test_ubuntu_24:
+    name: Smoke test (Ubuntu 24, x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download Linux Release Artifact
+        run: |
+          mkdir -p ./artifacts
+          gh release download ${{ env.VERSION }} \
+            --pattern "*linux_amd64.tar.gz" \
+            --dir ./artifacts \
+            --repo ${{ github.repository }}
+          # Rename to expected format
+          mv ./artifacts/*linux_amd64.tar.gz ./artifacts/linux.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Pull Ubuntu latest Image
+        run: docker pull ubuntu:latest
+
+      - name: Create and Start Ubuntu latest Container
+        run: |
+          docker run -d --name ubuntu-24-test -v ${{ github.workspace }}/artifacts:/artifacts -v ${{ github.workspace }}/scripts:/scripts ubuntu:latest tail -f /dev/null
+
+      - name: Get runner/container info
+        run: |
+          docker exec ubuntu-24-test /scripts/linux_container_info.sh
+
+      - name: Install dependencies, create user, and assign necessary permissions
+        run: |
+          docker exec ubuntu-24-test /scripts/prepare_ubuntu_container.sh
+
+      - name: Run smoke tests
+        run: |
+          docker exec -u tailpipe ubuntu-24-test /scripts/smoke_test.sh
+
+      - name: Stop and Remove Container
+        run: |
+          docker stop ubuntu-24-test
+          docker rm ubuntu-24-test
+
+  smoke_test_centos_9:
+    name: Smoke test (CentOS Stream 9, x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download Linux Release Artifact
+        run: |
+          mkdir -p ./artifacts
+          gh release download ${{ env.VERSION }} \
+            --pattern "*linux_amd64.tar.gz" \
+            --dir ./artifacts \
+            --repo ${{ github.repository }}
+          # Rename to expected format
+          mv ./artifacts/*linux_amd64.tar.gz ./artifacts/linux.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Pull CentOS Stream 9 image
+        run: docker pull quay.io/centos/centos:stream9
+
+      - name: Create and Start CentOS stream9 Container
+        run: |
+          docker run -d --name centos-stream9-test -v ${{ github.workspace }}/artifacts:/artifacts -v ${{ github.workspace }}/scripts:/scripts quay.io/centos/centos:stream9 tail -f /dev/null
+
+      - name: Get runner/container info
+        run: |
+          docker exec centos-stream9-test /scripts/linux_container_info.sh
+
+      - name: Install dependencies, create user, and assign necessary permissions
+        run: |
+          docker exec centos-stream9-test /scripts/prepare_centos_container.sh
+
+      - name: Run smoke tests
+        run: |
+          docker exec -u tailpipe centos-stream9-test /scripts/smoke_test.sh
+
+      - name: Stop and Remove Container
+        run: |
+          docker stop centos-stream9-test
+          docker rm centos-stream9-test
+
+  smoke_test_amazonlinux:
+    name: Smoke test (Amazon Linux 2023, x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download Linux Release Artifact
+        run: |
+          mkdir -p ./artifacts
+          gh release download ${{ env.VERSION }} \
+            --pattern "*linux_amd64.tar.gz" \
+            --dir ./artifacts \
+            --repo ${{ github.repository }}
+          # Rename to expected format
+          mv ./artifacts/*linux_amd64.tar.gz ./artifacts/linux.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Pull Amazon Linux 2023 Image
+        run: docker pull amazonlinux:2023
+
+      - name: Create and Start Amazon Linux 2023 Container
+        run: |
+          docker run -d --name amazonlinux-2023-test -v ${{ github.workspace }}/artifacts:/artifacts -v ${{ github.workspace }}/scripts:/scripts amazonlinux:2023 tail -f /dev/null
+
+      - name: Get runner/container info
+        run: |
+          docker exec amazonlinux-2023-test /scripts/linux_container_info.sh
+
+      - name: Install dependencies, create user, and assign necessary permissions
+        run: |
+          docker exec amazonlinux-2023-test /scripts/prepare_amazonlinux_container.sh
+
+      - name: Run smoke tests
+        run: |
+          docker exec -u tailpipe amazonlinux-2023-test /scripts/smoke_test.sh
+
+      - name: Stop and Remove Container
+        run: |
+          docker stop amazonlinux-2023-test
+          docker rm amazonlinux-2023-test
+
+  smoke_test_darwin_arm64:
+    name: Smoke test (macOS 14, ARM64)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download Darwin Release Artifact
+        run: |
+          mkdir -p ./artifacts
+          gh release download ${{ env.VERSION }} \
+            --pattern "*darwin_arm64.tar.gz" \
+            --dir ./artifacts \
+            --repo ${{ github.repository }}
+          # Rename to expected format
+          mv ./artifacts/*darwin_arm64.tar.gz ./artifacts/darwin.tar.gz
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Darwin Artifacts and Install Binary
+        run: |
+          mkdir -p /tmp/tailpipe
+          tar -xzf ./artifacts/darwin.tar.gz -C /tmp/tailpipe
+          sudo cp /tmp/tailpipe/tailpipe /usr/local/bin/
+          sudo chmod +x /usr/local/bin/tailpipe
+
+      - name: Install jq
+        run: |
+          brew install jq
+
+      - name: Get runner/container info
+        run: |
+          uname -a
+          sw_vers
+
+      - name: Run smoke tests
+        run: |
+          chmod +x $GITHUB_WORKSPACE/scripts/smoke_test.sh
+          $GITHUB_WORKSPACE/scripts/smoke_test.sh

--- a/scripts/linux_container_info.sh
+++ b/scripts/linux_container_info.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# This is a script to get the information about the linux container.
+# Used in release smoke tests.
+
+uname -a # uname information
+cat /etc/os-release # OS version information
+ldd --version # glibc version information 

--- a/scripts/prepare_amazonlinux_container.sh
+++ b/scripts/prepare_amazonlinux_container.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# This is a script to install dependencies/packages, create user, and assign necessary permissions in the Amazon Linux 2023 container.
+# Used in release smoke tests.
+
+# update yum and install required packages
+yum update -y
+yum install -y tar ca-certificates jq
+
+# Extract the tailpipe binary
+tar -xzf /artifacts/linux.tar.gz -C /usr/local/bin
+
+# Make the binary executable
+chmod +x /usr/local/bin/tailpipe
+
+# Create user, since tailpipe cannot be run as root
+useradd -m tailpipe
+
+# Make the scripts executable
+chown tailpipe:tailpipe /scripts/smoke_test.sh
+chmod +x /scripts/smoke_test.sh 

--- a/scripts/prepare_centos_container.sh
+++ b/scripts/prepare_centos_container.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# This is a script to install dependencies/packages, create user, and assign necessary permissions in the CentOS Stream 9 container.
+# Used in release smoke tests.
+
+# update yum and install required packages
+yum update -y
+yum install -y tar ca-certificates jq
+
+# Extract the tailpipe binary
+tar -xzf /artifacts/linux.tar.gz -C /usr/local/bin
+
+# Make the binary executable
+chmod +x /usr/local/bin/tailpipe
+
+# Create user, since tailpipe cannot be run as root
+useradd -m tailpipe
+
+# Make the scripts executable
+chown tailpipe:tailpipe /scripts/smoke_test.sh
+chmod +x /scripts/smoke_test.sh 

--- a/scripts/prepare_ubuntu_container.sh
+++ b/scripts/prepare_ubuntu_container.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# This is a script to install dependencies/packages, create user, and assign necessary permissions in the ubuntu 24 container.
+# Used in release smoke tests.
+
+# update apt and install required packages
+apt-get update
+apt-get install -y tar ca-certificates jq
+
+# Extract the tailpipe binary
+tar -xzf /artifacts/linux.tar.gz -C /usr/local/bin
+
+# Make the binary executable
+chmod +x /usr/local/bin/tailpipe
+
+# Create user, since tailpipe cannot be run as root
+useradd -m tailpipe
+
+# Make the scripts executable
+chown tailpipe:tailpipe /scripts/smoke_test.sh
+chmod +x /scripts/smoke_test.sh 

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# This is a script with set of commands to smoke test a tailpipe build.
+# The plan is to gradually add more tests to this script.
+
+set -e
+
+# Ensure the PATH includes the directory where jq is installed
+export PATH=$PATH:/usr/local/bin:/usr/bin:/bin
+
+# Check jq is available
+jq --version
+
+/usr/local/bin/tailpipe --version # check version
+
+# Test basic query functionality (should work without data)
+/usr/local/bin/tailpipe query "SELECT 1 as smoke_test" # verify basic query works
+
+# Test connect functionality
+DB_FILE=$(/usr/local/bin/tailpipe connect --output json | jq -r '.database_filepath')
+
+# Verify the database file exists
+if [ -f "$DB_FILE" ]; then
+    echo "Database file exists"
+else
+    echo "Database file not found: $DB_FILE"
+    exit 1
+fi
+
+# Test plugin installation
+/usr/local/bin/tailpipe plugin install chaos # install chaos plugin for testing
+/usr/local/bin/tailpipe plugin list # verify plugin is installed
+
+# Show available tables and sources after plugin installation
+/usr/local/bin/tailpipe table list # should now show chaos tables
+/usr/local/bin/tailpipe source list # should now show chaos sources
+
+# Create configuration for testing
+# the config path is different for darwin and linux
+if [ "$(uname -s)" = "Darwin" ]; then
+    CONFIG_DIR="/Users/runner/.tailpipe/config"
+else
+    CONFIG_DIR="/home/tailpipe/.tailpipe/config"
+fi
+
+mkdir -p "$CONFIG_DIR"
+
+# Create chaos.tpc configuration file
+cat > "$CONFIG_DIR/chaos.tpc" << 'EOF'
+partition "chaos_date_time" "chaos_date_time_range" {
+  source "chaos_date_time" {
+    row_count = 100
+  }
+}
+EOF
+
+cat "$CONFIG_DIR/chaos.tpc"
+
+# Test partition listing after adding configuration
+/usr/local/bin/tailpipe partition list # should now show the chaos partition
+
+# Show partition details
+/usr/local/bin/tailpipe partition show chaos_date_time.chaos_date_time_range
+
+# Test data collection - this is the main goal!
+/usr/local/bin/tailpipe collect chaos_date_time.chaos_date_time_range
+
+# Test querying collected data
+# Query 1: Count total rows
+/usr/local/bin/tailpipe query "SELECT COUNT(*) as total_rows FROM chaos_date_time" --output json
+
+# Query 2: Show first 5 rows
+/usr/local/bin/tailpipe query "SELECT * FROM chaos_date_time LIMIT 5" --output table
+
+# Query 3: Basic aggregation
+/usr/local/bin/tailpipe query "SELECT date_part('hour', datetime_col) as hour, COUNT(*) as count FROM chaos_date_time GROUP BY date_part('hour', datetime_col) ORDER BY hour LIMIT 5" --output json
+
+# Test plugin show functionality
+/usr/local/bin/tailpipe plugin show chaos


### PR DESCRIPTION
- Add 02-tailpipe-smoke-tests.yaml workflow for multi-platform testing
- Add smoke_test.sh script for comprehensive tailpipe testing
- Add container preparation scripts for Ubuntu, CentOS, and Amazon Linux
- Add linux_container_info.sh for system information gathering

This implements automated smoke testing triggered after releases to validate:
- Plugin installation and configuration
- Data collection using chaos plugin
- Basic and complex SQL queries
- Cross-platform compatibility (Linux distributions + macOS)