### PR TITLE
Pin docker/setup-buildx-action to SHA for org policy compliance

### DIFF
--- a/.github/workflows/01-tailpipe-release.yaml
+++ b/.github/workflows/01-tailpipe-release.yaml
@@ -111,7 +111,7 @@ jobs:
           ref: main
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Install Docker (if needed)
         run: |


### PR DESCRIPTION
The turbot org requires all GitHub Actions to be pinned to full-length commit SHAs. The release workflow had one unpinned reference (`docker/setup-buildx-action@v3`) that caused the `Build and Release Tailpipe` job to fail immediately on dispatch with:

```
The action docker/setup-buildx-action@v3 is not allowed in turbot/tailpipe because all actions must be pinned to a full-length commit SHA.
```

Pinned to v3.12.0 (`8d2750c68a42422c14e847fe6c8ac0403b4cbd6f`).