### PR TITLE
Add contents: write permission to release workflow

### DIFF
--- a/.github/workflows/01-tailpipe-release.yaml
+++ b/.github/workflows/01-tailpipe-release.yaml
@@ -21,6 +21,9 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: write
+
 env:
   TAILPIPE_UPDATE_CHECK: false
   GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
The `Tag Release` step runs `git push origin $VERSION` via the default `github-actions[bot]` token. Without an explicit `permissions` block, the token is read-only (org default), causing the job to fail with:

```
remote: Permission to turbot/tailpipe.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/turbot/tailpipe/': The requested URL returned error: 403
```

Steampipe's release workflow already has the equivalent `permissions: contents: write` block at the top. This brings tailpipe in line.