### PR TITLE
CHANGELOG for tailpipe v0.7.4 (pgx v5.9.2, CVE-2026-41889)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.7.4 [2026-05-19]
+_Dependencies_
+* Bump `github.com/jackc/pgx/v5` to v5.9.2 to remediate CVE-2026-41889 ([GHSA-j88v-2chj-qfwx](https://github.com/advisories/GHSA-j88v-2chj-qfwx)).
+* Update Go to 1.26.1.
+
 ## v0.7.3 [2026-04-22]
 _Bug fixes_
 * Fix `tailpipe plugin install` failing with an opaque `403 Forbidden` when stale GHCR credentials are present in `~/.docker/config.json` (e.g. from a prior `docker login`). Now retries the OCI pull anonymously when stored credentials are rejected. ([pipe-fittings#792](https://github.com/turbot/pipe-fittings/pull/792))


### PR DESCRIPTION
## Release prep (Phase A)

Adds the `CHANGELOG.md` entry for the next tailpipe patch release on the `v0.7.x` line, per the release_issue.md checklist item *"Changelog updated & reviewed before release."*

### Version note

Latest released tag on the `v0.7.x` line is **v0.7.3** (released 2026-04-23). The pgx v5.9.2 + Go 1.26.1 security fix (PR #608, commit `7c1c5bc`) landed on `v0.7.x` *after* the v0.7.3 tag, so the next version is **v0.7.4** (not v0.7.3 as originally anticipated).

### Changelog content

New top entry `## v0.7.4 [2026-05-19]` under a `_Dependencies_` section:

* Bump `github.com/jackc/pgx/v5` to v5.9.2 to remediate CVE-2026-41889 ([GHSA-j88v-2chj-qfwx](https://github.com/advisories/GHSA-j88v-2chj-qfwx)).
* Update Go to 1.26.1.

The underlying code change is already merged on `v0.7.x` via #608. This PR is documentation only — no merge, tag, or release performed here.
